### PR TITLE
Smoke Testing K3d

### DIFF
--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           push: true
           load: true 
-          tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
+          tags: ghcr.io/fastapigha/docker-ci-automation:${{ github.run_id }}
           target: test
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -69,7 +69,7 @@ jobs:
           export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
-          kubectl exec deploy/dateapi -- curl --fail http://localhost:8000/ date
+          kubectl exec deploy/dateapi -- curl --fail http://localhost:8000/date
 
       - name: Add Metadata
         id: docker_meta

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -63,10 +63,10 @@ jobs:
       - name: Deploy to K3d
         run: |
           kubectl create secret docker-registry regcred \
-            --docker-server=ghcr.io \
+            --docker-server=https://ghcr.io \
             --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.GHCR_TOKEN }} \
-          export TESTING_IMAGE="ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}"
+            --docker-password=${{ secrets.GHCR_TOKEN }}
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
           kubectl exec deploy/dateapi -- curl --fail http://localhost:8000/ date

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -66,7 +66,7 @@ jobs:
             --docker-server=https://ghcr.io \
             --docker-username=${{ github.actor }} \
             --docker-password=${{ secrets.GHCR_TOKEN }}
-          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
           kubectl logs deploy/dateapi

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -60,7 +60,7 @@ jobs:
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
 
-      -name: Test something
+      - name: Test something
         run: |
           export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | cat

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -69,6 +69,7 @@ jobs:
           export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
+          kubectl logs deploy/dateapi
           kubectl exec deploy/dateapi -- curl --fail http://localhost:8000/date
 
       - name: Add Metadata

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -60,6 +60,11 @@ jobs:
             --no-lb
             --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
 
+      -name: Test something
+        run: |
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
+          envsubst < manifests/deployment.yaml | cat
+      
       - name: Deploy to K3d
         run: |
           kubectl create secret docker-registry regcred \

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Test something
         run: |
-          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
+          export TESTING_IMAGE=ghcr.io/fastapigha/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | cat
       
       - name: Deploy to K3d
@@ -71,7 +71,7 @@ jobs:
             --docker-server=https://ghcr.io \
             --docker-username=${{ github.actor }} \
             --docker-password=${{ secrets.GHCR_TOKEN }}
-          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
+          export TESTING_IMAGE=ghcr.io/fastapigha/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
           kubectl logs deploy/dateapi

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           push: true
           load: true 
-          tags: ghcr.io/fastapigha/docker-ci-automation:${{ github.run_id }}
+          tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
           target: test
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -62,8 +62,13 @@ jobs:
 
       - name: Test something
         run: |
-          export TESTING_IMAGE=ghcr.io/fastapigha/docker-ci-automation:"$GITHUB_RUN_ID"
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | cat
+
+      - name: Test something docker run
+        run: |
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
+          docker run --rm $TESTING_IMAGE pytest
       
       - name: Deploy to K3d
         run: |
@@ -71,7 +76,7 @@ jobs:
             --docker-server=https://ghcr.io \
             --docker-username=${{ github.actor }} \
             --docker-password=${{ secrets.GHCR_TOKEN }}
-          export TESTING_IMAGE=ghcr.io/fastapigha/docker-ci-automation:"$GITHUB_RUN_ID"
+          export TESTING_IMAGE=ghcr.io/andjim/docker-ci-automation:"$GITHUB_RUN_ID"
           envsubst < manifests/deployment.yaml | kubectl apply -f -
           kubectl rollout status deployment dateapi
           kubectl logs deploy/dateapi

--- a/.github/workflows/10-add-k8s-test.yaml
+++ b/.github/workflows/10-add-k8s-test.yaml
@@ -1,0 +1,95 @@
+name: 10 - Image Build with Kubernetes Smoke Testing
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    # I could also choose which branch PR triggers
+
+jobs:
+  build-image:
+    name: Build Image
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Rust toolchain
+        run: |
+          curl https://sh.rustup.rs -sSf | sh -s -- -y
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+
+      # This action allows to build images using QEMU to emulate other architecture and build images for the chosen architecture
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{secrets.DOCKERHUB_USERNAME}}
+          password: ${{secrets.DOCKERHUB_TOKEN}}
+      
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
+      - name: Docker Build and push to GHCR
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          load: true 
+          tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}
+          target: test
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+
+      - name: Setup K3d
+        uses: AbsaOSS/k3d-action@v2
+        with:
+          cluster-name: "test-cluster"
+          args: >-
+            --agents 1
+            --no-lb
+            --k3s-arg "--no-deploy=traefik,servicelb,metrics-server@server:*"
+
+      - name: Deploy to K3d
+        run: |
+          kubectl create secret docker-registry regcred \
+            --docker-server=ghcr.io \
+            --docker-username=${{ github.actor }} \
+            --docker-password=${{ secrets.GHCR_TOKEN }} \
+          export TESTING_IMAGE="ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}"
+          envsubst < manifests/deployment.yaml | kubectl apply -f -
+          kubectl rollout status deployment dateapi
+          kubectl exec deploy/dateapi -- curl --fail http://localhost:8000/ date
+
+      - name: Add Metadata
+        id: docker_meta
+        uses: docker/metadata-action@v4
+        with:
+          images: andjim/docker-ci-automation
+          tags: |
+            type=raw,value=06
+            type=raw,value=latest,enable=${{ endsWith(github.ref, github.event.repository.default_branch) }}
+            type=ref,event=pr
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+
+      - name: Docker Build and Push to Docker Hub
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64 # With Qemu Action previously set, we now have available the param "platforms" where you can
+          # linux/arm/v7  not interested in this architecture for now.

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,7 @@ FROM base AS test
 # This stage is for running tests and development dependencies
 COPY ./requirements-dev.txt  .
 COPY ./test_main.py  .
+RUN apt-get install apache2-utils
 RUN pip install -r requirements-dev.txt
 CMD ["fastapi","dev","main.py"]
 #============================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY ./requirements-dev.txt  .
 COPY ./test_main.py  .
 RUN apt-get install curl -y
 RUN pip install -r requirements-dev.txt
-CMD ["fastapi","dev","main.py"]
+CMD ["fastapi","dev","main.py", "--host", "0.0.0.0", "--port", "8000"]
 #============================================================
 FROM base AS final
-CMD ["fastapi","run","main.py"]
+CMD ["fastapi","run","main.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,9 +21,9 @@ FROM base AS test
 # This stage is for running tests and development dependencies
 COPY ./requirements-dev.txt  .
 COPY ./test_main.py  .
-RUN apt-get install apache2-utils
+RUN apt-get install curl -y
 RUN pip install -r requirements-dev.txt
 CMD ["fastapi","dev","main.py"]
 #============================================================
-FROM base as final
+FROM base AS final
 CMD ["fastapi","run","main.py"]

--- a/README.md
+++ b/README.md
@@ -1,29 +1,3 @@
-____
-### 10-add-k8s-test.yaml
-
-**Purpose:**  
-This workflow introduces automated smoke testing of the Docker image in a real Kubernetes environment using k3d. It ensures that the image can be deployed and started successfully in a Kubernetes cluster, and that basic functionality is verified before the image is pushed to Docker Hub.
-
-**New Steps and Features:**
-- **Login to GHCR:**  
-  Authenticates to GitHub Container Registry (GHCR) to push the built image for use in the Kubernetes cluster.
-- **Docker Build and push to GHCR:**  
-  Builds the Docker image using the `test` stage, tags it for GHCR, and pushes it to the registry. The image is also loaded locally for immediate use in the k3d cluster.
-  - `tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}`: Tags the image for the current run.
-  - `push: true`, `load: true`: Pushes to GHCR and loads locally for k3d.
-- **Setup K3d:**  
-  Uses the `AbsaOSS/k3d-action` to create a lightweight Kubernetes cluster in Docker for testing.
-  - `cluster-name: "test-cluster"`: Names the test cluster.
-  - `args`: Configures the cluster (e.g., disables default load balancer and metrics server).
-- **Deploy to K3d:**  
-  - Creates a Kubernetes secret for pulling the image from GHCR.
-  - Uses `envsubst` to inject the image tag into the deployment manifest.
-  - Applies the manifest and waits for the deployment to roll out.
-  - Runs a smoke test by executing a `curl` command inside the deployed pod to verify the `/date` endpoint is reachable and functional.
-- **Kubernetes Manifest:**  
-  A new `manifests/deployment.yaml` file defines the deployment for the application, using the image built in the workflow.
-
-By running a smoke test in a real Kubernetes cluster, this workflow validates that the image can be pulled, started, and respond to basic requests in a production-like environment, increasing confidence in the deployment process.
 # Learning GHA and CI Automation with docker
 
 This repo is a "vile replication" of Bret Fisher's [docker-ci-automation](https://github.com/BretFisher/docker-ci-automation). It's me following step by step process on how to build a continuos integration workflow, which it's something I've interacted before, but with other tools and not me in the role of a CI workflow builder or maintainer (a simple developer hoping his PR not to fail any tests T.T). It's my first time working with Github Actions, so I'll be detailing the whats,whys, and hows of the workflows I'll be working with to be used for further references to whom might find it insterested (mostly for myself, please go check Bret Fisher's repo).
@@ -204,3 +178,29 @@ This workflow introduces automated integration testing to the CI pipeline using 
   - `docker compose -f docker-compose.test.yml up --exit-code-from test_suite`: Runs the integration test suite defined in the `docker-compose.test.yml` file and exits with the status of the `test_suite` service.
 
 By running integration tests in a Docker Compose environment, this workflow ensures that your application and its dependencies interact correctly, increasing confidence in the system as a whole before deployment.
+
+### 10-add-k8s-test.yaml
+
+**Purpose:**  
+This workflow introduces automated smoke testing of the Docker image in a real Kubernetes environment using k3d. It ensures that the image can be deployed and started successfully in a Kubernetes cluster, and that basic functionality is verified before the image is pushed to Docker Hub.
+
+**New Steps and Features:**
+- **Login to GHCR:**  
+  Authenticates to GitHub Container Registry (GHCR) to push the built image for use in the Kubernetes cluster.
+- **Docker Build and push to GHCR:**  
+  Builds the Docker image using the `test` stage, tags it for GHCR, and pushes it to the registry. The image is also loaded locally for immediate use in the k3d cluster.
+  - `tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}`: Tags the image for the current run.
+  - `push: true`, `load: true`: Pushes to GHCR and loads locally for k3d.
+- **Setup K3d:**  
+  Uses the `AbsaOSS/k3d-action` to create a lightweight Kubernetes cluster in Docker for testing.
+  - `cluster-name: "test-cluster"`: Names the test cluster.
+  - `args`: Configures the cluster (e.g., disables default load balancer and metrics server).
+- **Deploy to K3d:**  
+  - Creates a Kubernetes secret for pulling the image from GHCR.
+  - Uses `envsubst` to inject the image tag into the deployment manifest.
+  - Applies the manifest and waits for the deployment to roll out.
+  - Runs a smoke test by executing a `curl` command inside the deployed pod to verify the `/date` endpoint is reachable and functional.
+- **Kubernetes Manifest:**  
+  A new `manifests/deployment.yaml` file defines the deployment for the application, using the image built in the workflow.
+
+By running a smoke test in a real Kubernetes cluster, this workflow validates that the image can be pulled, started, and respond to basic requests in a production-like environment, increasing confidence in the deployment process.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,29 @@
+____
+### 10-add-k8s-test.yaml
+
+**Purpose:**  
+This workflow introduces automated smoke testing of the Docker image in a real Kubernetes environment using k3d. It ensures that the image can be deployed and started successfully in a Kubernetes cluster, and that basic functionality is verified before the image is pushed to Docker Hub.
+
+**New Steps and Features:**
+- **Login to GHCR:**  
+  Authenticates to GitHub Container Registry (GHCR) to push the built image for use in the Kubernetes cluster.
+- **Docker Build and push to GHCR:**  
+  Builds the Docker image using the `test` stage, tags it for GHCR, and pushes it to the registry. The image is also loaded locally for immediate use in the k3d cluster.
+  - `tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}`: Tags the image for the current run.
+  - `push: true`, `load: true`: Pushes to GHCR and loads locally for k3d.
+- **Setup K3d:**  
+  Uses the `AbsaOSS/k3d-action` to create a lightweight Kubernetes cluster in Docker for testing.
+  - `cluster-name: "test-cluster"`: Names the test cluster.
+  - `args`: Configures the cluster (e.g., disables default load balancer and metrics server).
+- **Deploy to K3d:**  
+  - Creates a Kubernetes secret for pulling the image from GHCR.
+  - Uses `envsubst` to inject the image tag into the deployment manifest.
+  - Applies the manifest and waits for the deployment to roll out.
+  - Runs a smoke test by executing a `curl` command inside the deployed pod to verify the `/date` endpoint is reachable and functional.
+- **Kubernetes Manifest:**  
+  A new `manifests/deployment.yaml` file defines the deployment for the application, using the image built in the workflow.
+
+By running a smoke test in a real Kubernetes cluster, this workflow validates that the image can be pulled, started, and respond to basic requests in a production-like environment, increasing confidence in the deployment process.
 # Learning GHA and CI Automation with docker
 
 This repo is a "vile replication" of Bret Fisher's [docker-ci-automation](https://github.com/BretFisher/docker-ci-automation). It's me following step by step process on how to build a continuos integration workflow, which it's something I've interacted before, but with other tools and not me in the role of a CI workflow builder or maintainer (a simple developer hoping his PR not to fail any tests T.T). It's my first time working with Github Actions, so I'll be detailing the whats,whys, and hows of the workflows I'll be working with to be used for further references to whom might find it insterested (mostly for myself, please go check Bret Fisher's repo).

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -24,3 +24,9 @@ spec:
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 8000
+          readinessProbe:
+            httpGet:
+              path: /date
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -22,3 +22,5 @@ spec:
         - name: dateapi
           image: "${TESTING_IMAGE}"
           imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 8000

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -1,0 +1,24 @@
+# kubernetes deployment
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dateapi
+  labels:
+    app: dateapi
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dateapi
+  template:
+    metadata:
+      labels:
+        app: dateapi
+    spec:
+      imagePullSecrets:
+        - name: regcred
+      containers:
+        - name: dateapi
+          image: "${TESTING_IMAGE}"
+          imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**Purpose:**  
This workflow introduces automated smoke testing of the Docker image in a real Kubernetes environment using k3d. It ensures that the image can be deployed and started successfully in a Kubernetes cluster, and that basic functionality is verified before the image is pushed to Docker Hub.

**New Steps and Features:**
- **Login to GHCR:**  
  Authenticates to GitHub Container Registry (GHCR) to push the built image for use in the Kubernetes cluster.
- **Docker Build and push to GHCR:**  
  Builds the Docker image using the `test` stage, tags it for GHCR, and pushes it to the registry. The image is also loaded locally for immediate use in the k3d cluster.
  - `tags: ghcr.io/andjim/docker-ci-automation:${{ github.run_id }}`: Tags the image for the current run.
  - `push: true`, `load: true`: Pushes to GHCR and loads locally for k3d.
- **Setup K3d:**  
  Uses the `AbsaOSS/k3d-action` to create a lightweight Kubernetes cluster in Docker for testing.
  - `cluster-name: "test-cluster"`: Names the test cluster.
  - `args`: Configures the cluster (e.g., disables default load balancer and metrics server).
- **Deploy to K3d:**  
  - Creates a Kubernetes secret for pulling the image from GHCR.
  - Uses `envsubst` to inject the image tag into the deployment manifest.
  - Applies the manifest and waits for the deployment to roll out.
  - Runs a smoke test by executing a `curl` command inside the deployed pod to verify the `/date` endpoint is reachable and functional.
- **Kubernetes Manifest:**  
  A new `manifests/deployment.yaml` file defines the deployment for the application, using the image built in the workflow.

By running a smoke test in a real Kubernetes cluster, this workflow validates that the image can be pulled, started, and respond to basic requests in a production-like environment, increasing confidence in the deployment process.